### PR TITLE
fix: long_task celery_id none error

### DIFF
--- a/saas/backend/long_task/tasks.py
+++ b/saas/backend/long_task/tasks.py
@@ -203,7 +203,7 @@ class TaskFactory(Task):
 
         params = handler.get_params()
 
-        celery_id = self.request.id
+        celery_id = self.request.id or ""
         TaskDetail.objects.filter(pk=id).update(
             celery_id=celery_id,
             status=TaskStatus.RUNNING.value,  # type: ignore[attr-defined]


### PR DESCRIPTION
## 变更点(Changes)

- 修复LongTask改同步后, celery_id获取为None的问题

## 相关issues (Which issues this PR fixes)

- Fixes #

## 备注(Special notes)

