### PR TITLE
Dev/ft ci

### DIFF
--- a/frontend/src/components/header/index.vue
+++ b/frontend/src/components/header/index.vue
@@ -3,7 +3,7 @@
     <header :class="[
         'header-layout',
         { 'nav-sticked': navStick, 'hide-bread': externalSystemsLayout.hideIamBreadCrumbs && !externalRouter.includes($route.name) },
-        { 'external-nav-sticked': externalRouter.includes($route.name) && externalSystemsLayout.hideIamBreadCrumbs }
+        { 'external-nav-sticked': isShowExternal }
     ]">
         <iam-guide
             v-if="showGuide"
@@ -14,7 +14,7 @@
             :content="$t(`m.guide['切换一级管理空间']`)" />
         <div class="breadcrumbs fl"
             :class="backRouter ? 'has-cursor' : ''"
-            v-show="externalRouter.includes($route.name) || (!mainContentLoading && !externalSystemsLayout.hideIamBreadCrumbs)"
+            v-show="isShowExternal || (!mainContentLoading && !externalSystemsLayout.hideIamBreadCrumbs)"
             @click="back">
             <div v-if="!isHide">
                 <Icon type="arrows-left" class="breadcrumbs-back" v-if="backRouter" />
@@ -278,6 +278,9 @@
             },
             isShowSearch () {
                 return this.searchValue === '';
+            },
+            isShowExternal () {
+               return this.externalRouter.includes(this.$route.name) && this.externalSystemsLayout.hideIamBreadCrumbs;
             }
         },
         watch: {

--- a/frontend/src/components/header/index.vue
+++ b/frontend/src/components/header/index.vue
@@ -3,7 +3,7 @@
     <header :class="[
         'header-layout',
         { 'nav-sticked': navStick, 'hide-bread': externalSystemsLayout.hideIamBreadCrumbs && !externalRouter.includes($route.name) },
-        { 'external-nav-sticked': externalRouter.includes($route.name) }
+        { 'external-nav-sticked': externalRouter.includes($route.name) && externalSystemsLayout.hideIamBreadCrumbs }
     ]">
         <iam-guide
             v-if="showGuide"
@@ -252,7 +252,7 @@
                 isShowHeader: false,
                 placeholderValue: '',
                 userGroupName: '',
-                externalRouter: ['permTransfer'] // 开放内嵌页面需要面包屑的页面
+                externalRouter: ['permTransfer', 'permRenewal'] // 开放内嵌页面需要面包屑的页面
             };
         },
         computed: {

--- a/frontend/src/components/render-renewal-dialog/index.vue
+++ b/frontend/src/components/render-renewal-dialog/index.vue
@@ -24,7 +24,7 @@
             <iam-deadline :value="expiredAt" @on-change="handleDeadlineChange" />
         </div>
         <div class="item">
-            <label :class="{ 'en': !curLanguageIsCn }">{{ $t(`m.common['到期时间']`) }}</label>
+            <label :class="{ 'en': !curLanguageIsCn }">{{ $t(`m.common['有效期']`) }}</label>
             <render-expire-display selected :renewal-time="expiredAt" :cur-time="curTime" />
         </div>
         <section slot="footer">

--- a/frontend/src/views/grading-admin/components/basic-info.vue
+++ b/frontend/src/views/grading-admin/components/basic-info.vue
@@ -34,7 +34,7 @@
                         :true-value="true"
                         :false-value="false"
                         class="select-wrap-checkbox"
-                        v-model="formData.syncPerm"
+                        v-model="formData.sync_perm"
                         @change="handleCheckboxChange">
                         {{ $t(`m.grading['同时具备空间下操作和资源权限']`) }}
                     </bk-checkbox>
@@ -59,7 +59,7 @@
         name: '',
         description: '',
         members: [],
-        syncPerm: false
+        sync_perm: false
     });
 
     export default {
@@ -96,13 +96,13 @@
             data: {
                 handler (value) {
                     if (Object.keys(value).length) {
-                        const { name, description, members, syncPerm } = value;
+                        const { name, description, members, sync_perm } = value;
                         this.displayMembers = members.map(e => e.username);
                         this.formData = Object.assign({}, {
                             name,
                             description,
                             members,
-                            syncPerm
+                            sync_perm
                         });
                     }
                 },
@@ -203,7 +203,7 @@
             },
 
             handleCheckboxChange () {
-                this.$emit('on-change', 'syncPerm', this.formData.syncPerm);
+                this.$emit('on-change', 'sync_perm', this.formData.sync_perm);
             }
         }
     };

--- a/frontend/src/views/grading-admin/create/index.vue
+++ b/frontend/src/views/grading-admin/create/index.vue
@@ -209,7 +209,7 @@
                     name: '',
                     description: '',
                     members: [],
-                    syncPerm: true
+                    sync_perm: true
                 },
                 addActionTips: this.$t(`m.grading['添加操作提示']`),
                 addMemberTips: this.$t(`m.grading['添加成员提示']`),
@@ -794,7 +794,7 @@
                         });
                     });
                 }
-                const { name, description, members, syncPerm } = this.formData;
+                const { name, description, members, sync_perm } = this.formData;
                 const params = {
                     name,
                     description,
@@ -802,7 +802,7 @@
                     subject_scopes: subjects,
                     authorization_scopes: data,
                     reason: this.reason,
-                    sync_perm: syncPerm
+                    sync_perm: sync_perm
                 };
                 try {
                     await this.$store.dispatch('role/addRatingManagerWithGeneral', params);

--- a/frontend/src/views/grading-admin/edit/index.vue
+++ b/frontend/src/views/grading-admin/edit/index.vue
@@ -181,7 +181,7 @@
                     name: '',
                     description: '',
                     members: [],
-                    syncPerm: false
+                    sync_perm: false
                 },
                 submitLoading: false,
                 addActionTips: this.$t(`m.grading['添加操作提示']`),
@@ -623,7 +623,7 @@
                     name,
                     description,
                     members,
-                    syncPerm: sync_perm
+                    sync_perm: sync_perm
                 });
                 const departments = [];
                 const users = [];
@@ -801,7 +801,7 @@
                         });
                     });
                 }
-                const { name, description, members, syncPerm } = this.formData;
+                const { name, description, members, sync_perm } = this.formData;
                 const params = {
                     name,
                     description,
@@ -810,7 +810,7 @@
                     authorization_scopes: data,
                     reason: this.reason,
                     id: this.$route.params.id,
-                    sync_perm: syncPerm
+                    sync_perm: sync_perm
                 };
                 console.log('params', params);
                 try {
@@ -884,7 +884,7 @@
                         });
                     });
                 }
-                const { name, description, members, syncPerm } = this.formData;
+                const { name, description, members, sync_perm } = this.formData;
                 const params = {
                     name,
                     description,
@@ -892,7 +892,7 @@
                     subject_scopes: subjects,
                     authorization_scopes: data,
                     id: this.$route.params.id,
-                    sync_perm: syncPerm
+                    sync_perm: sync_perm
                 };
                 this.submitLoading = true;
                 window.changeDialog = false;

--- a/frontend/src/views/group/clone/index.vue
+++ b/frontend/src/views/group/clone/index.vue
@@ -270,7 +270,7 @@
                 return this.tableList.length > 0;
             },
             isRatingManager () {
-                return this.user.role.type === 'rating_manager';
+                return ['rating_manager', 'subset_manager'].includes(this.user.role.type);
             },
             isSuperManager () {
                 return this.user.role.type === 'super_manager';
@@ -284,7 +284,7 @@
             }
         },
         mounted () {
-            this.formData.name = `${this.$route.query.name}_克隆`;
+            this.formData.name = `${this.$route.query.name}_${this.$t(`m.grading['克隆']`)}`;
             this.formData.description = this.$route.query.description;
             this.groupId = this.$route.query.id;
             console.log(this.groupId, this.groupId);

--- a/frontend/src/views/group/components/add-action-sideslider.vue
+++ b/frontend/src/views/group/components/add-action-sideslider.vue
@@ -17,7 +17,7 @@
                         <bk-input
                             clearable
                             right-icon="bk-icon icon-search"
-                            style="width: 190px;"
+                            style="max-width: calc(100% - 48px)"
                             v-model="keyword"
                             @input="handleInput"
                             @enter="handleSearch">

--- a/frontend/src/views/group/components/member-table.vue
+++ b/frontend/src/views/group/components/member-table.vue
@@ -165,7 +165,7 @@
                 return this.currentSelectList.length > 0 && this.tableList.length > 0;
             },
             isRatingManager () {
-                return this.user.role.type === 'rating_manager';
+                return ['rating_manager', 'subset_manager'].includes(this.user.role.type);
             },
             curType () {
                 return this.curData.type || 'department';

--- a/frontend/src/views/group/components/member-table.vue
+++ b/frontend/src/views/group/components/member-table.vue
@@ -37,7 +37,7 @@
                     <span :title="row.created_time.replace(/T/, ' ')">{{ row.created_time.replace(/T/, ' ') }}</span>
                 </template>
             </bk-table-column>
-            <bk-table-column :label="$t(`m.common['到期时间']`)" prop="expired_at_display"></bk-table-column>
+            <bk-table-column :label="$t(`m.common['有效期']`)" prop="expired_at_display"></bk-table-column>
             <bk-table-column :label="$t(`m.common['操作']`)" width="180">
                 <template slot-scope="{ row }">
                     <div>

--- a/frontend/src/views/group/create/index.vue
+++ b/frontend/src/views/group/create/index.vue
@@ -262,7 +262,7 @@
                 return this.tableList.length > 0;
             },
             isRatingManager () {
-                return this.user.role.type === 'rating_manager';
+                return ['rating_manager', 'subset_manager'].includes(this.user.role.type);
             },
             isSuperManager () {
                 return this.user.role.type === 'super_manager';

--- a/frontend/src/views/group/create/index.vue
+++ b/frontend/src/views/group/create/index.vue
@@ -772,10 +772,10 @@
                         templates
                     };
                     try {
-                        await this.$store.dispatch('userGroup/addUserGroup', params);
+                        const { data } = await this.$store.dispatch('userGroup/addUserGroup', params);
                         this.messageSuccess(this.$t(`m.info['新建用户组成功']`), 1000);
                         if (this.externalSystemId) { // 如果用户组新建成功需要发送一个postmessage给外部页面
-                            window.parent.postMessage({ type: 'IAM', code: 'create_user_group_submit' }, '*');
+                            window.parent.postMessage({ type: 'IAM', data, code: 'create_user_group_submit' }, '*');
                         } else {
                             bus.$emit('show-guide', 'process');
                             this.$router.push({

--- a/frontend/src/views/group/index.vue
+++ b/frontend/src/views/group/index.vue
@@ -300,7 +300,7 @@
                 return this.currentSelectList.length > 0;
             },
             isRatingManager () {
-                return this.curRole === 'rating_manager';
+                return ['rating_manager', 'subset_manager'].includes(this.curRole);
             },
             isSuperManager () {
                 return this.curRole === 'super_manager';

--- a/frontend/src/views/manage-spaces/authorization-boundary/edit/first-level.vue
+++ b/frontend/src/views/manage-spaces/authorization-boundary/edit/first-level.vue
@@ -183,7 +183,8 @@
                 formData: {
                     name: '',
                     description: '',
-                    members: []
+                    members: [],
+                    sync_perm: false
                 },
                 submitLoading: false,
                 addActionTips: this.$t(`m.levelSpace['二级管理空间，授权边界（授权操作范围、授权人员范围）小于等于一级管理员空间']`),
@@ -622,14 +623,16 @@
 
             handleDetailData (payload) {
                 console.log('payload', payload);
-                const { name, description, members } = payload;
+                const departments = [];
+                const users = [];
+                const { name, description, members, sync_perm } = payload;
+                this.$store.commit('setHeaderTitle', name);
                 this.formData = Object.assign({}, {
                     name,
                     description,
-                    members
+                    members,
+                    sync_perm
                 });
-                const departments = [];
-                const users = [];
                 payload.subject_scopes.forEach(item => {
                     if (item.type === 'department') {
                         departments.push({
@@ -804,7 +807,7 @@
                         });
                     });
                 }
-                const { name, description, members } = this.formData;
+                const { name, description, members, sync_perm } = this.formData;
                 const params = {
                     name,
                     description,
@@ -812,7 +815,8 @@
                     subject_scopes: subjects,
                     authorization_scopes: data,
                     reason: this.reason,
-                    id: this.$route.params.id
+                    id: this.$route.params.id,
+                    sync_perm
                 };
                 console.log('params', params);
                 try {
@@ -887,11 +891,12 @@
                         });
                     });
                 }
-                const { name, description, members } = this.formData;
+                const { name, description, members, sync_perm } = this.formData;
                 const params = {
                     name,
                     description,
                     members,
+                    sync_perm,
                     subject_scopes: subjects,
                     authorization_scopes: data,
                     id: this.$route.params.id

--- a/frontend/src/views/manage-spaces/components/basic-info-detail.vue
+++ b/frontend/src/views/manage-spaces/components/basic-info-detail.vue
@@ -64,7 +64,8 @@
                 formData: {
                     name: '',
                     description: '',
-                    members: []
+                    members: [],
+                    sync_perm: false
                 }
             };
         },
@@ -73,6 +74,7 @@
                 handler (value) {
                     if (Object.keys(value).length) {
                         this.formData = Object.assign({}, value);
+                        this.$store.commit('setHeaderTitle', this.formData.name);
                     }
                 },
                 immediate: true
@@ -103,20 +105,28 @@
         },
         methods: {
             handleUpdateRatingManager (payload) {
-                const { name, members, description } = this.formData;
+                const { name, members, description, sync_perm } = this.formData;
                 const params = {
                     name,
                     description,
                     members,
+                    sync_perm,
                     ...payload,
                     id: this.id
                 };
                 return this.$store.dispatch('spaceManage/updateSecondManagerManager', params)
                     .then(async () => {
                         this.messageSuccess(this.$t(`m.info['编辑成功']`), 2000);
-                        this.formData.name = params.name;
-                        this.formData.description = params.description;
-                        this.formData.members = [...params.members];
+                        const { name, description, members } = params;
+                        // this.formData.name = params.name;
+                        // this.formData.description = params.description;
+                        // this.formData.members = [...params.members];
+                        this.formData = Object.assign(this.formData, {
+                            name,
+                            description,
+                            members,
+                            sync_perm
+                        });
                         const headerTitle = params.name;
                         this.$store.commit('setHeaderTitle', headerTitle);
                         await this.$store.dispatch('roleList');

--- a/frontend/src/views/manage-spaces/components/basic-info.vue
+++ b/frontend/src/views/manage-spaces/components/basic-info.vue
@@ -24,7 +24,7 @@
                         :true-value="true"
                         :false-value="false"
                         class="select-wrap-checkbox"
-                        v-model="formData.syncPerm"
+                        v-model="formData.sync_perm"
                         @change="handleCheckboxChange">
                         {{ $t(`m.grading['同时具备空间下操作和资源权限']`) }}
                     </bk-checkbox>
@@ -45,7 +45,7 @@
         name: '',
         description: '',
         members: [],
-        syncPerm: false
+        sync_perm: false
     });
 
     export default {
@@ -76,14 +76,14 @@
             data: {
                 handler (value) {
                     if (Object.keys(value).length) {
-                        const { name, description, syncPerm } = value;
+                        const { name, description, sync_perm } = value;
                         this.displayMembers = value.members.filter(e => !e.readonly).map(e => e.username);
                         const members = value.members.filter(e => !e.readonly).map(e => e.username);
                         this.formData = Object.assign({}, {
                             name,
                             description,
                             members,
-                            syncPerm
+                            sync_perm
                         });
                     }
                 },
@@ -183,7 +183,7 @@
             },
 
             handleCheckboxChange () {
-                this.$emit('on-change', 'syncPerm', this.formData.syncPerm);
+                this.$emit('on-change', 'sync_perm', this.formData.sync_perm);
             }
         }
     };

--- a/frontend/src/views/manage-spaces/secondary-manage-space/create/index.vue
+++ b/frontend/src/views/manage-spaces/secondary-manage-space/create/index.vue
@@ -187,7 +187,7 @@
                     name: '',
                     description: '',
                     members: [],
-                    syncPerm: false
+                    sync_perm: false
                 },
                 isShowAddMemberDialog: false,
                 isShowMemberAdd: false,
@@ -374,7 +374,7 @@
                     name: `${name}_克隆`,
                     members,
                     description,
-                    syncPerm: sync_perm
+                    sync_perm: sync_perm
                 });
                 this.isAll = subject_scopes.some(item => item.type === '*' && item.id === '*');
                 this.users = subject_scopes.filter(item => item.type === 'user').map(item => {
@@ -1060,14 +1060,14 @@
                         });
                     });
                 }
-                const { name, description, members, syncPerm } = this.formData;
+                const { name, description, members, sync_perm } = this.formData;
                 const params = {
                     name,
                     description,
                     members,
                     subject_scopes: subjects,
                     authorization_scopes: data,
-                    sync_perm: syncPerm,
+                    sync_perm: sync_perm,
                     inherit_subject_scope: this.inheritSubjectScope
                 };
                 // 如果是动态继承上级空间 组织架构可为空

--- a/frontend/src/views/manage-spaces/secondary-manage-space/create/index.vue
+++ b/frontend/src/views/manage-spaces/secondary-manage-space/create/index.vue
@@ -298,7 +298,7 @@
                 return this.policyList.length > 0;
             },
             isRatingManager () {
-                return this.user.role.type === 'rating_manager';
+                return ['rating_manager', 'subset_manager'].includes(this.user.role.type);
             },
             isSuperManager () {
                 return this.user.role.type === 'super_manager';

--- a/frontend/src/views/my-manage-space/create/index.vue
+++ b/frontend/src/views/my-manage-space/create/index.vue
@@ -163,7 +163,7 @@
                     name: '',
                     description: '',
                     members: [],
-                    syncPerm: true
+                    sync_perm: true
                 },
                 users: [],
                 departments: [],
@@ -746,7 +746,7 @@
                         });
                     });
                 }
-                const { name, description, members, syncPerm } = this.formData;
+                const { name, description, members, sync_perm } = this.formData;
                 const params = {
                     name,
                     description,
@@ -754,7 +754,7 @@
                     subject_scopes: subjects,
                     authorization_scopes: data,
                     reason: this.reason,
-                    sync_perm: syncPerm
+                    sync_perm: sync_perm
                 };
                 try {
                     await this.$store.dispatch('role/addRatingManagerWithGeneral', params);
@@ -832,14 +832,14 @@
                         });
                     });
                 }
-                const { name, description, members, syncPerm } = this.formData;
+                const { name, description, members, sync_perm } = this.formData;
                 const params = {
                     name,
                     description,
                     members,
                     subject_scopes: subjects,
                     authorization_scopes: data,
-                    sync_perm: syncPerm
+                    sync_perm: sync_perm
                 };
                 window.changeDialog = false;
                 this.submitLoading = true;

--- a/frontend/src/views/perm/components/perm-table.vue
+++ b/frontend/src/views/perm/components/perm-table.vue
@@ -37,7 +37,7 @@
                         @click.stop="handleViewResource(row)" />
                 </template>
             </bk-table-column>
-            <bk-table-column prop="expired_dis" :label="$t(`m.common['到期时间']`)"></bk-table-column>
+            <bk-table-column prop="expired_dis" :label="$t(`m.common['有效期']`)"></bk-table-column>
             <bk-table-column :label="$t(`m.common['操作']`)">
                 <template slot-scope="{ row }">
                     <bk-button text @click="handleDelete(row)">{{ $t(`m.common['删除']`) }}</bk-button>

--- a/frontend/src/views/perm/components/render-renewal-table.vue
+++ b/frontend/src/views/perm/components/render-renewal-table.vue
@@ -242,13 +242,13 @@
                 if (payload === 'group') {
                     return [
                         { label: this.$t(`m.userGroup['用户组名']`), prop: 'name' },
-                        { label: this.$t(`m.common['到期时间']`), prop: 'expired_at' }
+                        { label: this.$t(`m.common['有效期']`), prop: 'expired_at' }
                     ];
                 }
                 return [
                     { label: this.$t(`m.common['操作']`), prop: 'action' },
                     { label: this.$t(`m.common['所属系统']`), prop: 'system' },
-                    { label: this.$t(`m.common['到期时间']`), prop: 'expired_at' }
+                    { label: this.$t(`m.common['有效期']`), prop: 'expired_at' }
                 ];
             },
 

--- a/frontend/src/views/perm/custom-perm/custom-perm-table.vue
+++ b/frontend/src/views/perm/custom-perm/custom-perm-table.vue
@@ -66,7 +66,7 @@
                     <div v-else class="condition-table-cell empty-text">{{ $t(`m.common['无生效条件']`) }}</div>
                 </template>
             </bk-table-column>
-            <bk-table-column prop="expired_dis" min-width="100" :label="$t(`m.common['到期时间']`)"></bk-table-column>
+            <bk-table-column prop="expired_dis" min-width="100" :label="$t(`m.common['有效期']`)"></bk-table-column>
             <bk-table-column :label="$t(`m.common['操作']`)">
                 <template slot-scope="{ row }">
                     <bk-button text @click="handleDelete(row)">{{ $t(`m.common['删除']`) }}</bk-button>

--- a/frontend/src/views/perm/department-group-perm/index.vue
+++ b/frontend/src/views/perm/department-group-perm/index.vue
@@ -44,8 +44,8 @@
                     </span>
                 </template>
             </bk-table-column>
-            <!-- 到期时间 -->
-            <bk-table-column :label="$t(`m.common['到期时间']`)" prop="expired_at_display"></bk-table-column>
+            <!-- 有效期 -->
+            <bk-table-column :label="$t(`m.common['有效期']`)" prop="expired_at_display"></bk-table-column>
             <!-- 操作 -->
             <bk-table-column :label="$t(`m.common['操作']`)" width="200">
                 <template slot-scope="props">

--- a/frontend/src/views/perm/group-perm-renewal/index.vue
+++ b/frontend/src/views/perm/group-perm-renewal/index.vue
@@ -40,7 +40,7 @@
                                     <span>{{ row.name }}({{ row.id }})</span>
                                 </template>
                             </bk-table-column>
-                            <bk-table-column :label="$t(`m.common['到期时间']`)">
+                            <bk-table-column :label="$t(`m.common['有效期']`)">
                                 <template slot-scope="{ row }">
                                     <render-expire-display
                                         :selected="currentSelectList.map((v) => v.$id).includes(row.$id)"

--- a/frontend/src/views/perm/group-perm/index.vue
+++ b/frontend/src/views/perm/group-perm/index.vue
@@ -44,8 +44,8 @@
                     </span>
                 </template>
             </bk-table-column>
-            <!-- 到期时间 -->
-            <bk-table-column :label="$t(`m.common['到期时间']`)" prop="expired_at_display"></bk-table-column>
+            <!-- 有效期 -->
+            <bk-table-column :label="$t(`m.common['有效期']`)" prop="expired_at_display"></bk-table-column>
             <!-- 操作 -->
             <bk-table-column :label="$t(`m.common['操作']`)" width="200">
                 <template slot-scope="props">

--- a/frontend/src/views/perm/template-perm/index.vue
+++ b/frontend/src/views/perm/template-perm/index.vue
@@ -14,7 +14,7 @@
                     </template>
                 </bk-table-column>
                 <bk-table-column :label="$t(`m.common['所属系统']`)" prop="system.name"></bk-table-column>
-                <bk-table-column :label="$t(`m.common['到期时间']`)" prop="expired_at_display"></bk-table-column>
+                <bk-table-column :label="$t(`m.common['有效期']`)" prop="expired_at_display"></bk-table-column>
                 <bk-table-column :label="$t(`m.perm['最近一次更新时间']`)">
                     <template slot-scope="{ row }">
                         <span :title="row.updated_time">{{ row.updated_time }}</span>

--- a/frontend/src/views/perm/teporary-custom-perm/custom-perm-table.vue
+++ b/frontend/src/views/perm/teporary-custom-perm/custom-perm-table.vue
@@ -66,7 +66,7 @@
                     <div v-else class="condition-table-cell empty-text">{{ $t(`m.common['无生效条件']`) }}</div>
                 </template>
             </bk-table-column>
-            <bk-table-column prop="expired_dis" :label="$t(`m.common['到期时间']`)"></bk-table-column>
+            <bk-table-column prop="expired_dis" :label="$t(`m.common['有效期']`)"></bk-table-column>
             <bk-table-column :label="$t(`m.common['操作']`)" width="180">
                 <template slot-scope="{ row }">
                     <bk-button text @click="handleDelete(row)">{{ $t(`m.common['删除']`) }}</bk-button>

--- a/frontend/src/views/transfer/custom-perm-table.vue
+++ b/frontend/src/views/transfer/custom-perm-table.vue
@@ -34,7 +34,7 @@
                     </template>
                 </template>
             </bk-table-column>
-            <bk-table-column prop="expired_dis" :label="$t(`m.common['到期时间']`)"></bk-table-column>
+            <bk-table-column prop="expired_dis" :label="$t(`m.common['有效期']`)"></bk-table-column>
         </bk-table>
     </div>
 </template>

--- a/frontend/src/views/transfer/group.vue
+++ b/frontend/src/views/transfer/group.vue
@@ -55,7 +55,7 @@
                                     </span>
                                 </template>
                             </bk-table-column>
-                            <bk-table-column :label="$t(`m.common['到期时间']`)" width="220">
+                            <bk-table-column :label="$t(`m.common['有效期']`)" width="220">
                                 <template slot-scope="{ row }">
                                     <span>{{row.expired_at_display}}</span>
                                 </template>

--- a/frontend/src/views/user/components/depart-perm.vue
+++ b/frontend/src/views/user/components/depart-perm.vue
@@ -23,7 +23,7 @@
                     </template>
                 </bk-table-column>
                 <bk-table-column :label="$t(`m.common['所属系统']`)" prop="system.name"></bk-table-column>
-                <bk-table-column :label="$t(`m.common['到期时间']`)" prop="expired_at_display"></bk-table-column>
+                <bk-table-column :label="$t(`m.common['有效期']`)" prop="expired_at_display"></bk-table-column>
                 <bk-table-column :label="$t(`m.perm['最近一次更新时间']`)">
                     <template slot-scope="{ row }">
                         <span :title="row.updated_time">{{ row.updated_time }}</span>

--- a/frontend/src/views/user/components/department-group-perm.vue
+++ b/frontend/src/views/user/components/department-group-perm.vue
@@ -44,8 +44,8 @@
                     </span>
                 </template>
             </bk-table-column>
-            <!-- 到期时间 -->
-            <bk-table-column :label="$t(`m.common['到期时间']`)" prop="expired_at_display"></bk-table-column>
+            <!-- 有效期 -->
+            <bk-table-column :label="$t(`m.common['有效期']`)" prop="expired_at_display"></bk-table-column>
             <!-- 操作 -->
             <bk-table-column :label="$t(`m.common['操作']`)" width="200">
                 <template slot-scope="props">

--- a/frontend/src/views/user/components/group-perm.vue
+++ b/frontend/src/views/user/components/group-perm.vue
@@ -25,7 +25,7 @@
                         <span class="user-group-name" :title="row.name" @click="goDetail(row)">{{ row.name }}</span>
                     </template>
                 </bk-table-column>
-                <bk-table-column :label="$t(`m.common['到期时间']`)" prop="expired_at_display"></bk-table-column>
+                <bk-table-column :label="$t(`m.common['有效期']`)" prop="expired_at_display"></bk-table-column>
                 <bk-table-column :label="$t(`m.perm['加入用户组的时间']`)">
                     <template slot-scope="{ row }">
                         <span :title="row.created_time">{{ row.created_time.replace(/T/, ' ') }}</span>

--- a/frontend/src/views/user/components/joined-user-group.vue
+++ b/frontend/src/views/user/components/joined-user-group.vue
@@ -21,7 +21,7 @@
                         <span class="user-group-name" :title="row.name" @click="goDetail(row)">{{ row.name }}</span>
                     </template>
                 </bk-table-column>
-                <bk-table-column :label="$t(`m.common['到期时间']`)" prop="expired_at_display"></bk-table-column>
+                <bk-table-column :label="$t(`m.common['有效期']`)" prop="expired_at_display"></bk-table-column>
                 <bk-table-column :label="$t(`m.perm['加入用户组的时间']`)">
                     <template slot-scope="{ row }">
                         <span :title="row.created_time">{{ row.created_time.replace(/T/, ' ') }}</span>

--- a/frontend/src/views/user/components/perm-table-edit.vue
+++ b/frontend/src/views/user/components/perm-table-edit.vue
@@ -37,7 +37,7 @@
                         @click.stop="handleViewResource(row)" />
                 </template>
             </bk-table-column>
-            <bk-table-column prop="expired_dis" :label="$t(`m.common['到期时间']`)"></bk-table-column>
+            <bk-table-column prop="expired_dis" :label="$t(`m.common['有效期']`)"></bk-table-column>
             <bk-table-column :label="$t(`m.common['操作']`)">
                 <template slot-scope="{ row }">
                     <bk-button text @click="handleDelete(row)">{{ $t(`m.common['删除']`) }}</bk-button>

--- a/frontend/src/views/user/components/perm-table.vue
+++ b/frontend/src/views/user/components/perm-table.vue
@@ -37,7 +37,7 @@
                         @click.stop="handleViewResource(row)" />
                 </template>
             </bk-table-column>
-            <bk-table-column prop="expired_dis" :label="$t(`m.common['到期时间']`)"></bk-table-column>
+            <bk-table-column prop="expired_dis" :label="$t(`m.common['有效期']`)"></bk-table-column>
             <bk-table-column :label="$t(`m.common['操作']`)">
                 <template slot-scope="{ row }">
                     <bk-button text @click="handleDelete(row)">{{ $t(`m.common['删除']`) }}</bk-button>

--- a/frontend/src/views/user/components/template-perm.vue
+++ b/frontend/src/views/user/components/template-perm.vue
@@ -16,7 +16,7 @@
                     </template>
                 </bk-table-column>
                 <bk-table-column :label="$t(`m.common['所属系统']`)" prop="system.name"></bk-table-column>
-                <bk-table-column :label="$t(`m.common['到期时间']`)" prop="expired_at_display"></bk-table-column>
+                <bk-table-column :label="$t(`m.common['有效期']`)" prop="expired_at_display"></bk-table-column>
                 <bk-table-column :label="$t(`m.perm['最近一次更新时间']`)">
                     <template slot-scope="{ row }">
                         <span :title="row.updated_time">{{ row.updated_time }}</span>

--- a/frontend/src/views/user/components/teporary-perm-table-edit.vue
+++ b/frontend/src/views/user/components/teporary-perm-table-edit.vue
@@ -37,7 +37,7 @@
                         @click.stop="handleViewResource(row)" />
                 </template>
             </bk-table-column>
-            <bk-table-column prop="expired_dis" :label="$t(`m.common['到期时间']`)"></bk-table-column>
+            <bk-table-column prop="expired_dis" :label="$t(`m.common['有效期']`)"></bk-table-column>
             <bk-table-column :label="$t(`m.common['操作']`)">
                 <template slot-scope="{ row }">
                     <bk-button text @click="handleDelete(row)">{{ $t(`m.common['删除']`) }}</bk-button>


### PR DESCRIPTION
feature: 权限中心授权边界 -> 管理员组跟勾选框没有同步， 统一同步权限字段名称
feature: 开放权限交接内嵌页面面包屑
feature: 权限中心的“到期时间”跟蓝盾保持一致，统一改为有效期
fix: 流水线级别（二级管理空间）组成员添加的时候，没有限制人员范围 ，应该跟一级管理空间保持一致
fix: 添加系统和操作宽度太长导致溢出
feature: 在内嵌页面增加创建用户组成功后提交id，方便父页面定位详情页