### PR TITLE
fix: 模板关联用户组页面下拉到底部后翻页按钮显示异常

### DIFF
--- a/frontend/src/views/grading-admin/components/add-action-sideslider.vue
+++ b/frontend/src/views/grading-admin/components/add-action-sideslider.vue
@@ -33,7 +33,7 @@
             <template>
               <template v-if="curSystemList.length > 0">
                 <div v-bkloading="{ isLoading: systemListIsLoading, opacity: 1 }">
-                  <div class="system-item single-hide"
+                  <div class="flex-between system-item"
                     v-for="item in curSystemList"
                     :key="item.id"
                     :class="item.id === curSystem ? 'active' : ''"

--- a/frontend/src/views/group/components/add-action-sideslider.vue
+++ b/frontend/src/views/group/components/add-action-sideslider.vue
@@ -32,7 +32,7 @@
           <div :class="['system-wrapper', curSystemList.length > 20 ? 'system-item-fixed' : '']">
             <template v-if="curSystemList.length > 0">
               <div v-bkloading="{ isLoading: systemListIsLoading, opacity: 1 }">
-                <div class="system-item"
+                <div class="flex-between system-item"
                   v-for="item in curSystemList"
                   :key="item.id"
                   :class="item.id === curSystem ? 'active' : ''"

--- a/frontend/src/views/group/index.vue
+++ b/frontend/src/views/group/index.vue
@@ -712,7 +712,8 @@
           {
             limit: 10,
             current: 1,
-            count: 0
+            count: 0,
+            showTotalCount: true
           }
         );
       },

--- a/frontend/src/views/manage-spaces/secondary-manage-space/components/add-action-sideslider.vue
+++ b/frontend/src/views/manage-spaces/secondary-manage-space/components/add-action-sideslider.vue
@@ -32,7 +32,7 @@
           <div :class="['system-wrapper', curSystemList.length > 20 ? 'system-item-fixed' : '']">
             <template v-if="curSystemList.length">
               <div v-bkloading="{ isLoading: systemListIsLoading, opacity: 1 }">
-                <div class="system-item"
+                <div class="flex-between system-item"
                   v-for="item in curSystemList"
                   :key="item.id"
                   :class="item.id === curSystem ? 'active' : ''"

--- a/frontend/src/views/perm-template/detail/attach-group.vue
+++ b/frontend/src/views/perm-template/detail/attach-group.vue
@@ -7,6 +7,7 @@
       size="small"
       :class="{ 'set-border': tableLoading }"
       ext-cls="perm-template-attach-member-table"
+      :max-height="tableHeight"
       :pagination="pagination"
       @page-change="handlePageChange"
       @page-limit-change="handleLimitChange"
@@ -54,10 +55,10 @@
 <script>
   import DeleteDialog from '@/components/iam-confirm-dialog/index.vue';
   import PermSideslider from '../components/render-group-perm-sideslider';
-  import { formatCodeData } from '@/common/util';
+  import { getWindowHeight, formatCodeData } from '@/common/util';
 
   export default {
-    name: '',
+    inject: ['showNoticeAlert'],
     components: {
       DeleteDialog,
       PermSideslider
@@ -90,7 +91,8 @@
           text: '',
           tip: '',
           tipType: ''
-        }
+        },
+        tableHeight: 0
       };
     },
     watch: {
@@ -101,7 +103,18 @@
     created () {
       this.fetchData(true);
     },
+    mounted () {
+      this.getTableHeight();
+      window.addEventListener('resize', this.getTableHeight);
+      this.$once('hook:beforeDestroy', () => {
+        window.removeEventListener('resize', this.getTableHeight);
+      });
+    },
     methods: {
+      getTableHeight () {
+        const defaultHeight = getWindowHeight() - 185;
+        this.tableHeight = this.showNoticeAlert ? defaultHeight - 40 : defaultHeight;
+      },
       async fetchData (isTabLoading = false, isTableLoading = false) {
         this.tableLoading = isTableLoading;
         this.tabLoading = isTabLoading;


### PR DESCRIPTION
[模板关联用户组页面下拉到底部后翻页按钮显示异常](https://github.com/TencentBlueKing/bk-iam-saas/pull/2675/commits/56a0a33069be526c021e83ddcec7b60703ac5dcf)
[fix: 用户组页面删除用户组后，用户组数量展示消失](https://github.com/TencentBlueKing/bk-iam-saas/pull/2675/commits/95caf5343ccceef242bdec00daeb4da63eeb705e)