### PR TITLE
fix: remove erroneous call on ancestor_department_ids property

### DIFF
--- a/saas/backend/api/external/staff_movement/serializers.py
+++ b/saas/backend/api/external/staff_movement/serializers.py
@@ -18,7 +18,7 @@ def validate_rtx(value):
     user = User.objects.filter(username=value).first()
     if not user:
         raise serializers.ValidationError("rtx not exists")
-    if len(set(settings.PCG_DEPARTMENT_IDS) & set(user.ancestor_department_ids())) == 0:
+    if len(set(settings.PCG_DEPARTMENT_IDS) & set(user.ancestor_department_ids)) == 0:
         raise serializers.ValidationError("rtx is not in the specified organization")
     return value
 


### PR DESCRIPTION
ancestor_department_ids is a @property returning List[int], not a method. Calling it with () causes 'list object is not callable' error.

<!--
请保证PR标题明确清晰, 易于理解
Keep PR title verbose enough

相关issue可以是 #编号 或者贴 issue链接
`Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


## 变更点(Changes)

- xxxx

## 相关issues (Which issues this PR fixes)

- Fixes #

## 备注(Special notes)

