### PR TITLE
fix: remove TenantMixin dependency from SystemClientCheckMixin

### DIFF
--- a/saas/backend/api/authorization/permissions.py
+++ b/saas/backend/api/authorization/permissions.py
@@ -69,7 +69,7 @@ class AuthorizationAPIPermission(
         system_slz = AuthSystemSLZ(data=request.data)
         system_slz.is_valid(raise_exception=True)
         system_id = system_slz.validated_data["system"]
-        self.verify_system_client(system_id, app_code)
+        self.verify_system_client(request.tenant_id, system_id, app_code)
 
         # 如果仅仅是校验System，则上面已校验，可以直接忽略了
         if param_source == VerifyApiParamLocationEnum.SYSTEM_IN_BODY.value:

--- a/saas/backend/api/management/mixins.py
+++ b/saas/backend/api/management/mixins.py
@@ -69,11 +69,11 @@ class ManagementAPIPermissionCheckMixin(SystemClientCheckMixin):
                     )
                 )
 
-    def verify_api(self, app_code: str, system_id: str, api: ManagementAPIEnum):
+    def verify_api(self, tenant_id: str, app_code: str, system_id: str, api: ManagementAPIEnum):
         """
         该方法为最常用的API认证和鉴权方法，包括：校验app_code与system和校验管理类API权限
         """
         # API认证
-        self.verify_system_client(system_id, app_code)
+        self.verify_system_client(tenant_id, system_id, app_code)
         # API鉴权
         self.verify_api_allow_list(system_id, api)

--- a/saas/backend/api/management/v1/permissions.py
+++ b/saas/backend/api/management/v1/permissions.py
@@ -109,7 +109,7 @@ class ManagementAPIPermission(permissions.IsAuthenticated, ManagementAPIPermissi
             slz.is_valid(raise_exception=True)
             source_system_id = slz.validated_data["system"]
 
-            self.verify_api(app_code, source_system_id, api)
+            self.verify_api(request.tenant_id, app_code, source_system_id, api)
             return
 
         # 参数来自 body data - group_ids
@@ -138,7 +138,7 @@ class ManagementAPIPermission(permissions.IsAuthenticated, ManagementAPIPermissi
             )
 
         # API 认证和 API 鉴权
-        self.verify_api(app_code, role_source.source_system_id, api)
+        self.verify_api(tenant_id, app_code, role_source.source_system_id, api)
 
     def _verify_api_by_group(self, tenant_id: str, app_code: str, group_id: int, api: ManagementAPIEnum):
         """

--- a/saas/backend/api/management/v2/permissions.py
+++ b/saas/backend/api/management/v2/permissions.py
@@ -78,7 +78,7 @@ class ManagementAPIPermission(permissions.IsAuthenticated, ManagementAPIPermissi
 
         # 对于所有 V2 API 都需要校验（1）app_code 与 system client (2) 校验 systems 是否有 API 白名单权限
         system_id = request.parser_context["kwargs"]["system_id"]
-        self.verify_api(app_code, system_id, api)
+        self.verify_api(request.tenant_id, app_code, system_id, api)
 
         # 对于仅需校验路径里的 System，则上面 verify_api 已经校验
         if param_source == VerifyApiParamLocationEnum.SYSTEM_IN_PATH.value:
@@ -159,7 +159,7 @@ class ManagementAPIPermission(permissions.IsAuthenticated, ManagementAPIPermissi
             source_system_id = role_source.source_system_id
 
         # API 认证和 API 鉴权
-        self.verify_api(app_code, source_system_id, api)
+        self.verify_api(tenant_id, app_code, source_system_id, api)
 
     def _verify_api_by_group(
         self, tenant_id: str, app_code: str, group_id: int, api: ManagementAPIEnum, system_id: str

--- a/saas/backend/api/mixins.py
+++ b/saas/backend/api/mixins.py
@@ -12,16 +12,15 @@ specific language governing permissions and limitations under the License.
 from rest_framework import exceptions
 
 from backend.biz.system import SystemBiz
-from backend.mixins import TenantMixin
 
 
-class SystemClientCheckMixin(TenantMixin):
-    def verify_system_client(self, system_id: str, app_code: str):
+class SystemClientCheckMixin:
+    def verify_system_client(self, tenant_id: str, system_id: str, app_code: str):
         """
         验证 app_code 是否能访问系统
         """
 
-        clients = SystemBiz(self.tenant_id).list_client(system_id)
+        clients = SystemBiz(tenant_id).list_client(system_id)
 
         if app_code not in clients:
             raise exceptions.PermissionDenied(


### PR DESCRIPTION
SystemClientCheckMixin inherited TenantMixin which accesses self.request.tenant_id, but Permission classes do not have self.request set by DRF, causing AttributeError.
Pass tenant_id explicitly through verify_system_client and verify_api method parameters instead.

<!--
请保证PR标题明确清晰, 易于理解
Keep PR title verbose enough

相关issue可以是 #编号 或者贴 issue链接
`Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


## 变更点(Changes)

- xxxx

## 相关issues (Which issues this PR fixes)

- Fixes #

## 备注(Special notes)

